### PR TITLE
[Feature] added optin/optout and trackLocation to the AdobeAnalytics instance

### DIFF
--- a/adobe-analytics.android.d.ts
+++ b/adobe-analytics.android.d.ts
@@ -17,5 +17,10 @@ export declare class AdobeAnalytics extends AdobeAnalyticsCommon {
         [key: string]: any;
     }): void;
     trackTimedActionEnd(action: string): void;
+    trackLocation(location: android.location.Location, additional: {
+        [key: string]: any;
+    }): void;
+    optin(): void;
+    optout(): void;
     private convertToHashMap(dictionary?);
 }

--- a/adobe-analytics.android.ts
+++ b/adobe-analytics.android.ts
@@ -39,6 +39,18 @@ export class AdobeAnalytics extends AdobeAnalyticsCommon {
         com.adobe.mobile.Analytics.trackTimedActionEnd(action, null);
     }
 
+    public trackLocation(location: android.location.Location, additional: { [key: string]: any; }): void {
+        com.adobe.mobile.Analytics.trackLocation(location, this.convertToHashMap(additional));
+    }
+
+    public optin(): void {
+        com.adobe.mobile.Config.setPrivacyStatus(com.adobe.mobile.MobilePrivacyStatus.MOBILE_PRIVACY_STATUS_OPT_IN);
+    }
+
+    public optout(): void {
+        com.adobe.mobile.Config.setPrivacyStatus(com.adobe.mobile.MobilePrivacyStatus.MOBILE_PRIVACY_STATUS_OPT_OUT);
+    }
+
     private convertToHashMap(dictionary: { [key: string]: any } = {}): java.util.Map<string, Object> {
         return Object.keys(dictionary)
             .reduce((result, key) => {

--- a/adobe-analytics.common.d.ts
+++ b/adobe-analytics.common.d.ts
@@ -18,4 +18,9 @@ export declare abstract class AdobeAnalyticsCommon {
         [key: string]: any;
     }): void;
     abstract trackTimedActionEnd(action: string): void;
+    abstract trackLocation(location: android.location.Location | CLLocation, additional: {
+        [key: string]: any;
+    }): void;
+    abstract optin(): void;
+    abstract optout(): void;
 }

--- a/adobe-analytics.common.ts
+++ b/adobe-analytics.common.ts
@@ -20,4 +20,7 @@ export abstract class AdobeAnalyticsCommon {
     public abstract trackTimedActionStart(action: string, additional: { [key: string]: any }): void;
     public abstract trackTimedActionUpdate(action: string, additional: { [key: string]: any }): void;
     public abstract trackTimedActionEnd(action: string): void;
+    public abstract trackLocation(location: android.location.Location | CLLocation, additional: { [key: string]: any; }): void;
+    public abstract optin(): void;
+    public abstract optout(): void;
 }

--- a/adobe-analytics.ios.d.ts
+++ b/adobe-analytics.ios.d.ts
@@ -17,4 +17,9 @@ export declare class AdobeAnalytics extends AdobeAnalyticsCommon {
         [key: string]: any;
     }): void;
     trackTimedActionEnd(action: string): void;
+    trackLocation(location: CLLocation, additional: {
+        [key: string]: any;
+    }): void;
+    optin(): void;
+    optout(): void;
 }

--- a/adobe-analytics.ios.ts
+++ b/adobe-analytics.ios.ts
@@ -35,4 +35,16 @@ export class AdobeAnalytics extends AdobeAnalyticsCommon {
     public trackTimedActionEnd(action: string): void {
         ADBMobile.trackTimedActionEndLogic(action, null);
     }
+
+    public trackLocation(location: CLLocation, additional: { [key: string]: any; }): void {
+        ADBMobile.trackLocationData(location, <NSDictionary<any, any>>additional);
+    }
+
+    public optin(): void {
+        ADBMobile.setPrivacyStatus(ADBMobilePrivacyStatus.OptIn);
+    }
+
+    public optout(): void {
+        ADBMobile.setPrivacyStatus(ADBMobilePrivacyStatus.OptOut);
+    }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,4 +19,7 @@ export declare class AdobeAnalytics extends AdobeAnalyticsCommon {
         [key: string]: any;
     }): void;
     trackTimedActionEnd(action: string): void;
+    trackLocation(location: android.location.Location | CLLocation, additional: { [key: string]: any; }): void;
+    optin(): void;
+    optout(): void;
 }


### PR DESCRIPTION
trackLocation accepts the Location/CLLocation which can be obtained from nativescript-geolocation plugin calls. This is esp. simpler then creating a Location instance on Android from lat./long.