### PR TITLE
Removed dependency on android typings from tns-platform-declarations

### DIFF
--- a/adobe-analytics.common.d.ts
+++ b/adobe-analytics.common.d.ts
@@ -2,8 +2,8 @@ export declare abstract class AdobeAnalyticsCommon {
     protected static _instance: AdobeAnalyticsCommon;
     constructor();
     static getInstance(): AdobeAnalyticsCommon;
-    abstract setContext(applicationContext: android.content.Context): void;
-    abstract collectLifecycleData(activity: android.app.Activity, debugLogging?: boolean): void;
+    abstract setContext(applicationContext: any ): void; //applicationContext type is android.content.Context
+    abstract collectLifecycleData(activity: any, debugLogging?: boolean): void; //activity type is android.app.Activity
     abstract pauseCollectingLifecycleData(): any;
     abstract trackState(state: string, additional: {
         [key: string]: any;

--- a/demo/package.json
+++ b/demo/package.json
@@ -25,7 +25,6 @@
     "karma-nativescript-launcher": "^0.4.0",
     "lazy": "1.0.11",
     "nativescript-dev-typescript": "~0.4.5",
-    "typescript": "2.3.4",
-    "tns-platform-declarations": "3.1.0"
+    "typescript": "2.3.4"
   }
 }

--- a/demo/references.d.ts
+++ b/demo/references.d.ts
@@ -1,2 +1,1 @@
 /// <reference path="./node_modules/tns-core-modules/tns-core-modules.d.ts" />
-/// <reference path="./node_modules/tns-platform-declarations/android.d.ts" />


### PR DESCRIPTION
Removed the android typings to remove the dependency of android.d.ts from tns-platform-delclarations. This gives currently issues with AOT (out of memory problems while bundling).