### PR TITLE
Added visitorAppendToURL(string): string

### DIFF
--- a/adobe-analytics.android.d.ts
+++ b/adobe-analytics.android.d.ts
@@ -18,4 +18,5 @@ export declare class AdobeAnalytics extends AdobeAnalyticsCommon {
     }): void;
     trackTimedActionEnd(action: string): void;
     private convertToHashMap(dictionary?);
+    visitorAppendToURL(url: string): string;
 }

--- a/adobe-analytics.android.ts
+++ b/adobe-analytics.android.ts
@@ -48,4 +48,8 @@ export class AdobeAnalytics extends AdobeAnalyticsCommon {
             }, new java.util.HashMap<string, Object>());
     }
 
+    public visitorAppendToURL(url: string): string {
+        return com.adobe.mobile.Visitor.appendToURL(url);
+    }
+
 }

--- a/adobe-analytics.common.d.ts
+++ b/adobe-analytics.common.d.ts
@@ -18,4 +18,5 @@ export declare abstract class AdobeAnalyticsCommon {
         [key: string]: any;
     }): void;
     abstract trackTimedActionEnd(action: string): void;
+    abstract visitorAppendToURL(url: string): string;
 }

--- a/adobe-analytics.common.ts
+++ b/adobe-analytics.common.ts
@@ -20,4 +20,5 @@ export abstract class AdobeAnalyticsCommon {
     public abstract trackTimedActionStart(action: string, additional: { [key: string]: any }): void;
     public abstract trackTimedActionUpdate(action: string, additional: { [key: string]: any }): void;
     public abstract trackTimedActionEnd(action: string): void;
+    public abstract visitorAppendToURL(url: string): string;
 }

--- a/adobe-analytics.ios.d.ts
+++ b/adobe-analytics.ios.d.ts
@@ -17,4 +17,5 @@ export declare class AdobeAnalytics extends AdobeAnalyticsCommon {
         [key: string]: any;
     }): void;
     trackTimedActionEnd(action: string): void;
+    visitorAppendToURL(url: string): string;
 }

--- a/adobe-analytics.ios.ts
+++ b/adobe-analytics.ios.ts
@@ -35,4 +35,11 @@ export class AdobeAnalytics extends AdobeAnalyticsCommon {
     public trackTimedActionEnd(action: string): void {
         ADBMobile.trackTimedActionEndLogic(action, null);
     }
+
+    public visitorAppendToURL(url: string): string {
+        const nsurl = NSURL.URLWithString(url);
+        const urlWithVisitorData = ADBMobile.visitorAppendToURL(nsurl);
+
+        return urlWithVisitorData.absoluteString;
+    }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,4 +19,5 @@ export declare class AdobeAnalytics extends AdobeAnalyticsCommon {
         [key: string]: any;
     }): void;
     trackTimedActionEnd(action: string): void;
+    visitorAppendToURL(url: string): string;
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "Jasper Boeijenga <jasper.boeijenga@essent.nl>",
     "Henk Bakker <spike1292@gmail.com>",
     "Oscar Lodriguez <o.lodriguez@gmail.com>",
-    "Robert Jan Van der Hulst <rvdhulst@quintor.nl>"
+    "Robert Jan Van der Hulst <rvdhulst@quintor.nl>",
+    "Steve Jackson <stevenljackson1@gmail.com>"
   ],
   "license": "MIT",
   "homepage": "https://github.com/Essent/nativescript-adobe-marketing-cloud",


### PR DESCRIPTION
Adds the user's ID to the specified URL as a querystring parameter. This can be used to prevent double-counting of visitors to your mobile on your website when they view your website via a mobile web view in your app.